### PR TITLE
Upgrade various github actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,16 +11,17 @@ jobs:
     name: "build"
     runs-on: "ubuntu-latest"
     steps:
-    - uses: "actions/checkout@v2"
+    - uses: "actions/checkout@v3"
     - uses: "gradle/wrapper-validation-action@v1"
-    - uses: "actions/cache@v2"
+    - uses: "actions/cache@v3"
       with:
         "path": "~/.gradle/caches"
         "key": "${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}"
         "restore-keys": "${{ runner.os }}-gradle-"
-    - uses: "actions/setup-java@v1"
+    - uses: "actions/setup-java@v3"
       with:
         "java-version": "15"
+        "distribution": "zulu"
     - name: "compile and run tests"
       run: "./gradlew build"
     - name: "Set image version"
@@ -32,13 +33,13 @@ jobs:
         echo "IMAGE=${IMAGE}" >> $GITHUB_ENV
         echo "image=${IMAGE}" >> ${GITHUB_OUTPUT}
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and push
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         context: .
         push: true
@@ -50,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: "actions/checkout@v3"
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ jobs:
     name: "Deploy AiviA"
     runs-on: ubuntu-latest
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: "actions/checkout@v3"
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}


### PR DESCRIPTION
The upgrade of setup-java required a new `with`, `distribution`. I set it to zulu which should result in equal java distribution as v1.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/